### PR TITLE
Fixed SMC readout for temperature on Mac Book Pro 2018

### DIFF
--- a/Turbo Boost Disabler/SystemCommands.m
+++ b/Turbo Boost Disabler/SystemCommands.m
@@ -252,6 +252,11 @@ int SMCGetFanSpeed(char *key)
                 int intValue = (val.bytes[0] * 256 + val.bytes[1]) >> 2;
                 return intValue;
             }
+            else if (strcmp(val.dataType, DATATYPE_FLT) == 0) {
+                float fVal;
+                memcpy(&fVal,val.bytes,sizeof(float));
+                return (int)fVal;
+            }
         }
     }
     // read failed

--- a/Turbo Boost Disabler/smc.h
+++ b/Turbo Boost Disabler/smc.h
@@ -38,6 +38,7 @@
 #define SMC_CMD_READ_PLIMIT   11
 #define SMC_CMD_READ_VERS     12
 
+#define DATATYPE_FLT          "flt "
 #define DATATYPE_FPE2         "fpe2"
 #define DATATYPE_UINT8        "ui8 "
 #define DATATYPE_UINT16       "ui16"


### PR DESCRIPTION
This fixes the SMC readout changes on new MacBooks