### PR TITLE
Clarify the "Disable at Launch" menu option

### DIFF
--- a/en.lproj/Localizable.strings
+++ b/en.lproj/Localizable.strings
@@ -12,7 +12,7 @@
 "enable_menu" = "Enable Turbo Boost";
 "disable_menu" = "Disable Turbo Boost";
 "open_login" = "Open at Login";
-"disable_login" = "Disable at Launch";
+"disable_login" = "Disable Turbo Boost at Launch";
 "settings" = "Settings:";
 "donate" = "Donate...";
 "about" = "About...";


### PR DESCRIPTION
It's not immediately clear whether "Disable at Launch" disables Turbo Boost at launch or the kext. This just clarifies it.